### PR TITLE
fix: use platform-independent paths to make vite hmr work on windows

### DIFF
--- a/lib/vite/plugin.js
+++ b/lib/vite/plugin.js
@@ -1,5 +1,10 @@
 const path = require('path');
 
+const normalizePath = (p) => {
+  const isWindows = typeof process !== 'undefined' && process.platform === 'win32';
+  return path.posix.normalize(isWindows ? p.replace(/\\/g, '/') : p);
+};
+
 module.exports.i18nextHMRPlugin = function i18nextHMRPlugin(options) {
   let absoluteLocaleDirs = [];
 
@@ -10,19 +15,20 @@ module.exports.i18nextHMRPlugin = function i18nextHMRPlugin(options) {
         .concat(options.localesDir, options.localesDirs)
         .filter(Boolean)
         .map((localeDir) =>
-          path.isAbsolute(localeDir)
-            ? localeDir
-            : path.resolve(config.root || process.cwd(), localeDir)
+          normalizePath(
+            path.isAbsolute(localeDir)
+              ? localeDir
+              : path.resolve(config.root || process.cwd(), localeDir)
+          )
         );
     },
     handleHotUpdate({ file, server }) {
       const relevantLocaleDir = absoluteLocaleDirs.find((dir) => file.startsWith(dir));
       if (relevantLocaleDir) {
         const fileExt = path.extname(file);
+        const relativePath = path.posix.relative(relevantLocaleDir, file);
         server.ws.send('i18next-hmr:locale-changed', {
-          changedFiles: [
-            path.relative(relevantLocaleDir, file).slice(0, -1 * fileExt.length || undefined),
-          ],
+          changedFiles: [relativePath.slice(0, -1 * fileExt.length || undefined)],
         });
       }
     },


### PR DESCRIPTION
Thanks for creating this great plugin!

This PR fixes an issue where Vite HMR doesn't work on Windows due to inconsistent path separators.

As noted in [Vite Plugin API docs](https://vite.dev/guide/api-plugin.html#path-normalization):

> For Vite plugins, when comparing paths against resolved ids it is important to first normalize the paths to use POSIX separators.

In this fix, paths are now normalized to use forward slashes before adding to `absoluteLocaleDirs` for later comparisons. Implementation of `normalizePath` is basically based on [Vite's code](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/utils.ts#L244-L246).
